### PR TITLE
Input Cached Stream 동시성 문제 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add the dependency to your `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("com.github.codexwr:spring-boot-request-logging:2.0.3")
+    implementation("com.github.codexwr:spring-boot-request-logging:2.0.4")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "com.github.codexwr"
-version = "2.0.3"
+version = "2.0.4"
 
 java {
     toolchain {

--- a/src/main/java/com/github/codexwr/springbootrequestlogging/servlet/CachedResponseWrapper.java
+++ b/src/main/java/com/github/codexwr/springbootrequestlogging/servlet/CachedResponseWrapper.java
@@ -24,14 +24,6 @@ class CachedResponseWrapper extends HttpServletResponseWrapper implements Loggin
         return getCachedOutputStream();
     }
 
-    @Override
-    public PrintWriter getWriter() throws IOException {
-        if (!isCachedBody())
-            return super.getWriter();
-
-        return getPrintWriterWrapper();
-    }
-
     private ServletOutputStream getCachedOutputStream() throws IOException {
         if (cachedOutputStream != null)
             return cachedOutputStream;
@@ -39,6 +31,14 @@ class CachedResponseWrapper extends HttpServletResponseWrapper implements Loggin
         cachedOutputStream = new CachedOutputStream(super.getOutputStream());
 
         return cachedOutputStream;
+    }
+
+    @Override
+    public PrintWriter getWriter() throws IOException {
+        if (!isCachedBody())
+            return super.getWriter();
+
+        return getPrintWriterWrapper();
     }
 
     private PrintWriterWrapper getPrintWriterWrapper() throws IOException {


### PR DESCRIPTION
This pull request refactors the request and response caching logic to simplify the implementation and improve thread safety. The changes primarily focus on replacing the use of `FastByteArrayOutputStream` with standard Java classes, optimizing the caching mechanism, and cleaning up the code structure for better maintainability.

### Request and Response Caching Refactor

* Replaced `FastByteArrayOutputStream` and `InputStream` in `CachedInputStream` with a simpler `ByteArrayInputStream`-based implementation, and updated related methods for improved clarity and correctness. [[1]](diffhunk://#diff-d6adac84e3b9cde98d5c8a2014e44697d5e9aafb351b73fa004143a63745bcfeR3-R15) [[2]](diffhunk://#diff-d6adac84e3b9cde98d5c8a2014e44697d5e9aafb351b73fa004143a63745bcfeL30-L38) [[3]](diffhunk://#diff-d6adac84e3b9cde98d5c8a2014e44697d5e9aafb351b73fa004143a63745bcfeL47-R50)
* Refactored `CachedRequestWrapper` to use a volatile byte array (`cachedData`) for thread-safe request body caching, and simplified the logic for obtaining cached streams and readers. [[1]](diffhunk://#diff-1d439632f2dfe7e75f0780264e7c1a8870aeb323486214992451c64dc6d55de2L30-R30) [[2]](diffhunk://#diff-1d439632f2dfe7e75f0780264e7c1a8870aeb323486214992451c64dc6d55de2L45-R60) [[3]](diffhunk://#diff-1d439632f2dfe7e75f0780264e7c1a8870aeb323486214992451c64dc6d55de2L137-R134)

### Code Structure and Consistency

* Rearranged the `getWriter` method in `CachedResponseWrapper` for better code organization and consistency, moving it after the output stream logic. [[1]](diffhunk://#diff-704b246f8ad5376da16f0952916f6ef9f5d60c021ffad10a52273fb70e5c8c54L27-L34) [[2]](diffhunk://#diff-704b246f8ad5376da16f0952916f6ef9f5d60c021ffad10a52273fb70e5c8c54R36-R43)

### Dependency Update

* Updated the library version in the `README.md` to `2.0.4` to reflect the latest changes.