### PR TITLE
Feature/refactor printer

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add the dependency to your `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("com.github.codexwr:spring-boot-request-logging:2.0.5")
+    implementation("com.github.codexwr:spring-boot-request-logging:2.1.0")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "com.github.codexwr"
-version = "2.0.5"
+version = "2.1.0"
 
 java {
     toolchain {

--- a/src/main/java/com/github/codexwr/springbootrequestlogging/configuration/LogPrinter.java
+++ b/src/main/java/com/github/codexwr/springbootrequestlogging/configuration/LogPrinter.java
@@ -6,12 +6,26 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
+import org.springframework.util.Assert;
+
+import java.util.Map;
 
 public interface LogPrinter {
     @Nullable
     UsernameProvider usernameProvider();
 
-    void request(@Nonnull HttpMethod httpMethod, @Nonnull String url, @Nullable String queryString, @Nullable String remoteAddr, @Nullable String sessionId, @Nullable HttpHeaders header, @Nullable MediaType bodyContentType, @Nullable String body);
+    void request(@Nonnull LogItem logItem);
 
-    void response(@Nullable Long executionTime, @Nonnull HttpStatusCode httpStatus, @Nonnull HttpMethod httpMethod, @Nonnull String url, @Nullable String queryString, @Nullable MediaType requestBodyContentType, @Nullable String requestBody, @Nullable MediaType responseBodyContentType, @Nullable String responseBody);
+    void response(@Nullable Long executionTime, @Nonnull HttpStatusCode httpStatus, @Nonnull LogItem logItem);
+
+    record LogItem(@Nonnull HttpMethod httpMethod, @Nonnull String url, @Nullable String queryString,
+                   @Nullable String remoteAddr, @Nullable String sessionId, @Nullable HttpHeaders header,
+                   @Nullable MediaType requestBodyContentType, @Nullable String requestBody,
+                   @Nullable MediaType responseBodyContentType, @Nullable String responseBody,
+                   @Nullable Map<String, String> extraInfo) {
+        public LogItem {
+            Assert.notNull(httpMethod, "httpMethod must not be null");
+            Assert.notNull(url, "url must not be null");
+        }
+    }
 }

--- a/src/main/java/com/github/codexwr/springbootrequestlogging/configuration/LoggingFilterProperties.java
+++ b/src/main/java/com/github/codexwr/springbootrequestlogging/configuration/LoggingFilterProperties.java
@@ -160,6 +160,38 @@ public class LoggingFilterProperties {
      */
     private String exitPrefixDecor = "[-] ";
 
+    /**
+     * A list of default log items to be included in request logging.
+     * This list defines the specific elements of a request that will be logged by default.
+     * The default log items include:
+     * - URL: The request URL.
+     * - CLIENT_INFO: Client-related information (e.g., IP address, session ID).
+     * - USERNAME: Username of the authenticated user, if available.
+     * - HEADER: HTTP headers of the request.
+     * - EXTRA_INFO: Additional contextual information provided during the request.
+     * - REQUEST_BODY: The body content of the request.
+     */
+    private List<DefaultLogItemType> defaultRequestLogItems = List.of(
+            DefaultLogItemType.URL,
+            DefaultLogItemType.CLIENT_INFO,
+            DefaultLogItemType.USERNAME,
+            DefaultLogItemType.HEADER,
+            DefaultLogItemType.EXTRA_INFO,
+            DefaultLogItemType.REQUEST_BODY
+    );
+
+    /**
+     * A list of default log items to be included in response logging.
+     */
+    private List<DefaultLogItemType> defaultResponseLogItems = List.of(
+            DefaultLogItemType.URL,
+            DefaultLogItemType.CLIENT_INFO,
+            DefaultLogItemType.USERNAME,
+            DefaultLogItemType.EXTRA_INFO,
+            DefaultLogItemType.REQUEST_BODY,
+            DefaultLogItemType.RESPONSE_BODY
+    );
+
     @Data
     @NoArgsConstructor
     public static class ExcludeLoggingPath {
@@ -210,5 +242,9 @@ public class LoggingFilterProperties {
         public void setMethod(String method) {
             this.method = HttpMethod.valueOf(method.toUpperCase());
         }
+    }
+
+    public enum DefaultLogItemType {
+        URL, HEADER, CLIENT_INFO, USERNAME, REQUEST_BODY, RESPONSE_BODY, EXTRA_INFO
     }
 }

--- a/src/main/java/com/github/codexwr/springbootrequestlogging/reactor/DefaultReactiveLoggingFilter.java
+++ b/src/main/java/com/github/codexwr/springbootrequestlogging/reactor/DefaultReactiveLoggingFilter.java
@@ -28,9 +28,10 @@ class DefaultReactiveLoggingFilter implements LoggingFilter {
         if (isIgnoreLogging(exchange.getRequest()))
             return chain.filter(exchange);
 
-        return new LoggingWebExchange(exchange, logPrinter, enableLoggingRequestBody, enableLoggingResponseBody)
+        LoggingWebExchange webExchange = new LoggingWebExchange(exchange, logPrinter, enableLoggingRequestBody, enableLoggingResponseBody);
+        return webExchange
                 .enableLogging()
-                .flatMap(chain::filter);
+                .flatMap(it -> chain.filter(it).onErrorResume(webExchange::enableResponseLoggingWhenError));
     }
 
     private boolean isIgnoreLogging(ServerHttpRequest request) {

--- a/src/main/java/com/github/codexwr/springbootrequestlogging/reactor/LoggingRequestDecorator.java
+++ b/src/main/java/com/github/codexwr/springbootrequestlogging/reactor/LoggingRequestDecorator.java
@@ -26,18 +26,10 @@ class LoggingRequestDecorator extends ServerHttpRequestDecorator implements Logg
 
     public Mono<Void> logPrint() {
         executionTime = System.currentTimeMillis();
-        var exchange = exchangeSupplier.get();
 
-        return Mono.zip(exchange.getSession(), getRequestBody())
-                .doOnNext(sessionAndBody -> logPrinter.request(getMethod(),
-                        getURI().getPath(),
-                        getURI().getQuery(),
-                        getRemoteAddress() != null ? getRemoteAddress().getHostString() : null,
-                        sessionAndBody.getT1().isStarted() ? sessionAndBody.getT1().getId() : null,
-                        getHeaders(),
-                        getContentType(),
-                        sessionAndBody.getT2().orElse(null))
-                ).then();
+        return getLogItem(exchangeSupplier.get(), this, null, null)
+                .doOnNext(logPrinter::request)
+                .then();
     }
 
     public Mono<Optional<String>> getRequestBody() {

--- a/src/main/java/com/github/codexwr/springbootrequestlogging/reactor/LoggingResponseDecorator.java
+++ b/src/main/java/com/github/codexwr/springbootrequestlogging/reactor/LoggingResponseDecorator.java
@@ -46,11 +46,12 @@ class LoggingResponseDecorator extends ServerHttpResponseDecorator implements Lo
         super.beforeCommit(() -> action.get().then(logPrint()));
     }
 
-    private Mono<Void> logPrint() {
+    public Mono<Void> logPrint() {
+        var exchange = exchangeSupplier.get();
         return Mono.just(true)
                 .takeUntilOther(printComplete.asMono())
                 .doOnNext(it -> printComplete.tryEmitEmpty())
-                .flatMap(it -> getLogItem(exchangeSupplier.get(), loggingRequestDelegate, this, null))
+                .flatMap(it -> getLogItem(exchange, loggingRequestDelegate, this, null))
                 .doOnNext(logItem -> {
                     logPrinter.response(executionTime(),
                             Objects.requireNonNullElse(getStatusCode(), HttpStatus.VARIANT_ALSO_NEGOTIATES),

--- a/src/main/java/com/github/codexwr/springbootrequestlogging/reactor/LoggingResponseDecorator.java
+++ b/src/main/java/com/github/codexwr/springbootrequestlogging/reactor/LoggingResponseDecorator.java
@@ -7,6 +7,7 @@ import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.http.server.reactive.ServerHttpResponseDecorator;
+import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
 
@@ -15,14 +16,16 @@ import java.util.function.Supplier;
 
 class LoggingResponseDecorator extends ServerHttpResponseDecorator implements LoggingDecorator {
     private final LoggingRequestDecorator loggingRequestDelegate;
+    private final Supplier<ServerWebExchange> exchangeSupplier;
     private final LogPrinter logPrinter;
 
     private final Sinks.Empty<Void> printComplete = Sinks.empty();
 
-    public LoggingResponseDecorator(ServerHttpResponse delegate, LoggingRequestDecorator loggingRequestDelegate, LogPrinter logPrinter) {
+    public LoggingResponseDecorator(ServerHttpResponse delegate, Supplier<ServerWebExchange> exchangeSupplier, LoggingRequestDecorator loggingRequestDelegate, LogPrinter logPrinter) {
         super(delegate);
 
         this.loggingRequestDelegate = loggingRequestDelegate;
+        this.exchangeSupplier = exchangeSupplier;
         this.logPrinter = logPrinter;
     }
 
@@ -46,21 +49,17 @@ class LoggingResponseDecorator extends ServerHttpResponseDecorator implements Lo
     private Mono<Void> logPrint() {
         return Mono.just(true)
                 .takeUntilOther(printComplete.asMono())
-                .map(it -> printComplete.tryEmitEmpty())
-                .flatMap(it -> loggingRequestDelegate.getRequestBody())
-                .doOnNext(requestBody -> logPrinter.response(executionTime(),
-                        Objects.requireNonNullElse(getStatusCode(), HttpStatus.VARIANT_ALSO_NEGOTIATES),
-                        loggingRequestDelegate.getMethod(),
-                        loggingRequestDelegate.getURI().getPath(),
-                        loggingRequestDelegate.getURI().getQuery(),
-                        loggingRequestDelegate.getHeaders().getContentType(),
-                        requestBody.orElse(null),
-                        getHeaders().getContentType(),
-                        getResponseBody())
-                ).then();
+                .doOnNext(it -> printComplete.tryEmitEmpty())
+                .flatMap(it -> getLogItem(exchangeSupplier.get(), loggingRequestDelegate, this, null))
+                .doOnNext(logItem -> {
+                    logPrinter.response(executionTime(),
+                            Objects.requireNonNullElse(getStatusCode(), HttpStatus.VARIANT_ALSO_NEGOTIATES),
+                            logItem
+                    );
+                }).then();
     }
 
-    private String getResponseBody() {
+    public String getResponseBody() {
         var delegate = getNativeResponse(getDelegate(), CachedResponseDecorator.class);
         if (delegate != null) {
             return delegate.getCachedContentString();

--- a/src/main/java/com/github/codexwr/springbootrequestlogging/reactor/LoggingWebExchange.java
+++ b/src/main/java/com/github/codexwr/springbootrequestlogging/reactor/LoggingWebExchange.java
@@ -25,7 +25,7 @@ class LoggingWebExchange extends ServerWebExchangeDecorator {
 
         // logger
         loggingRequestDecorator = new LoggingRequestDecorator(req, this::getDelegate, logPrinter);
-        loggingResponseDecorator = new LoggingResponseDecorator(res, loggingRequestDecorator, logPrinter);
+        loggingResponseDecorator = new LoggingResponseDecorator(res, this::getDelegate, loggingRequestDecorator, logPrinter);
     }
 
     @Override

--- a/src/main/java/com/github/codexwr/springbootrequestlogging/reactor/LoggingWebExchange.java
+++ b/src/main/java/com/github/codexwr/springbootrequestlogging/reactor/LoggingWebExchange.java
@@ -4,6 +4,7 @@ import com.github.codexwr.springbootrequestlogging.configuration.LogPrinter;
 import jakarta.annotation.Nonnull;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.web.ErrorResponseException;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.ServerWebExchangeDecorator;
 import reactor.core.publisher.Mono;
@@ -42,5 +43,17 @@ class LoggingWebExchange extends ServerWebExchangeDecorator {
 
     public Mono<ServerWebExchange> enableLogging() {
         return Mono.defer(() -> loggingRequestDecorator.logPrint().then(Mono.just(this)));
+    }
+
+    public Mono<Void> enableResponseLoggingWhenError(Throwable error) {
+        return Mono.defer(() -> {
+                    if (loggingResponseDecorator.getStatusCode() == null) {
+                        if (error instanceof ErrorResponseException statusException)
+                            loggingResponseDecorator.setStatusCode(statusException.getStatusCode());
+                    }
+
+                    return loggingResponseDecorator.logPrint();
+                })
+                .then(Mono.error(error));
     }
 }

--- a/src/main/java/com/github/codexwr/springbootrequestlogging/servlet/LoggingRequestWrapper.java
+++ b/src/main/java/com/github/codexwr/springbootrequestlogging/servlet/LoggingRequestWrapper.java
@@ -5,7 +5,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 import lombok.Getter;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.web.util.WebUtils;
 
 class LoggingRequestWrapper extends HttpServletRequestWrapper implements LoggingWrapper {
@@ -22,17 +21,7 @@ class LoggingRequestWrapper extends HttpServletRequestWrapper implements Logging
     public void logPrint() {
         executionTime = System.currentTimeMillis();
 
-        var session = getSession(false);
-
-        logPrinter.request(getHttpMethod(),
-                getRequestURI(),
-                getQueryString(),
-                getRemoteAddr(),
-                session != null ? session.getId() : null,
-                new ServletServerHttpRequest(this).getHeaders(),
-                getContentType(getContentType()),
-                getRequestBody()
-        );
+        logPrinter.request(getLogItem(this, null, null));
     }
 
     public HttpMethod getHttpMethod() {

--- a/src/main/java/com/github/codexwr/springbootrequestlogging/servlet/LoggingResponseWrapper.java
+++ b/src/main/java/com/github/codexwr/springbootrequestlogging/servlet/LoggingResponseWrapper.java
@@ -19,15 +19,10 @@ class LoggingResponseWrapper extends HttpServletResponseWrapper implements Loggi
     }
 
     public void logPrint() {
-        logPrinter.response(executionTime(),
+        logPrinter.response(
+                executionTime(),
                 HttpStatusCode.valueOf(getStatus()),
-                loggingRequestWrapper.getHttpMethod(),
-                loggingRequestWrapper.getRequestURI(),
-                loggingRequestWrapper.getQueryString(),
-                getContentType(loggingRequestWrapper.getContentType()),
-                loggingRequestWrapper.getRequestBody(),
-                getContentType(getContentType()),
-                getResponseBody()
+                getLogItem(loggingRequestWrapper, this, null)
         );
     }
 

--- a/src/main/java/com/github/codexwr/springbootrequestlogging/servlet/LoggingWrapper.java
+++ b/src/main/java/com/github/codexwr/springbootrequestlogging/servlet/LoggingWrapper.java
@@ -1,12 +1,16 @@
 package com.github.codexwr.springbootrequestlogging.servlet;
 
+import com.github.codexwr.springbootrequestlogging.configuration.LogPrinter;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
-import org.springframework.web.util.WebUtils;
+import org.springframework.http.server.ServletServerHttpRequest;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 interface LoggingWrapper {
     Logger log = LoggerFactory.getLogger(LoggingWrapper.class);
@@ -37,4 +41,20 @@ interface LoggingWrapper {
     }
 
     String getContentType();
+
+    default LogPrinter.LogItem getLogItem(@Nonnull LoggingRequestWrapper request, @Nullable LoggingResponseWrapper response, @Nullable Map<String, String> extraInfo) {
+        return new LogPrinter.LogItem(
+                request.getHttpMethod(),
+                request.getRequestURI(),
+                request.getQueryString(),
+                request.getRemoteAddr(),
+                request.getSession(false) != null ? request.getSession(false).getId() : null,
+                new ServletServerHttpRequest(request).getHeaders(),
+                getContentType(request.getContentType()),
+                request.getRequestBody(),
+                response != null ? getContentType(response.getContentType()) : null,
+                response != null ? response.getResponseBody() : null,
+                extraInfo
+        );
+    }
 }

--- a/src/test/java/com/github/codexwr/springbootrequestlogging/web/ReactiveLoggingTest.java
+++ b/src/test/java/com/github/codexwr/springbootrequestlogging/web/ReactiveLoggingTest.java
@@ -122,4 +122,20 @@ public class ReactiveLoggingTest {
                 .exchange()
                 .expectStatus().isOk();
     }
+
+    @Test
+    @DisplayName("No URL PATH")
+    public void noUrl() {
+        // given
+        var member = new WebTestApplication.Member("Alice", 20);
+
+        // when
+        webClient.post()
+                .uri("/no-url-path")
+                .headers(it -> it.addAll(headers))
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(member)
+                .exchange()
+                .expectStatus().is4xxClientError();
+    }
 }

--- a/src/test/java/com/github/codexwr/springbootrequestlogging/web/ServletLoggingTest.java
+++ b/src/test/java/com/github/codexwr/springbootrequestlogging/web/ServletLoggingTest.java
@@ -105,4 +105,19 @@ public class ServletLoggingTest {
                 .andExpect(status().isOk())
                 .andDo(MockMvcResultHandlers.print());
     }
+
+    @Test
+    @DisplayName("No URL PATH")
+    public void noUrl() throws Exception {
+        var member = new WebTestApplication.Member("Alice", 20);
+
+        // when
+        var req = post("/no-url-path")
+                .headers(headers)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(member));
+        mvc.perform(req)
+                .andExpect(status().is4xxClientError())
+                .andDo(MockMvcResultHandlers.print());
+    }
 }


### PR DESCRIPTION
This pull request introduces a significant refactor and enhancement to the logging infrastructure, focusing on unifying and simplifying how request and response log data is constructed and processed. The main improvements include the introduction of a `LogItem` record to encapsulate log details, configurable default log item types, and streamlined logging logic across both servlet and reactive stacks.

**Key changes:**

### Logging API & Data Model Refactor

* Introduced the `LogPrinter.LogItem` record, which encapsulates all relevant request/response logging data, replacing the previous long parameter lists in the `LogPrinter` interface. The `request` and `response` methods now accept a single `LogItem` argument. [[1]](diffhunk://#diff-6c7a8e27cab6718f5cb40b415b0fdbd04dfa786e7051f1e4ce16647c2e1cb353R9-R30) [[2]](diffhunk://#diff-6d68e1741faa4269d3c94cd2c131a1d566c0b3d0e06eddc9800a9a81cc8d98a9L32-R80)
* Updated all usages in both servlet and reactive implementations to construct and pass `LogItem` objects, centralizing logic for assembling log data. [[1]](diffhunk://#diff-366fc532f28869946674aebb06ba0ef1d8e91f23cb69b7046c7270bcc92b5cb8L25-R24) [[2]](diffhunk://#diff-010b1a629855df31ad3d49a7bc528a9594ee64afbb428acbf4578935fbd173bfL22-R25) [[3]](diffhunk://#diff-b5bae5dddc0656d0928fff3acf2ea4caf023d4ec3f81d8936691535bdfc4581aR73-R96) [[4]](diffhunk://#diff-4be7c3ecb4515c947043ac90377ecd7389d4d5709b203474354afe3f4d337f23L29-R32) [[5]](diffhunk://#diff-592c8cf980a74997bf3255218680383c77eca2a35d67453821b7cdead500a0d4L46-R63)

### Configurability & Extensibility

* Added `defaultRequestLogItems` and `defaultResponseLogItems` lists to `LoggingFilterProperties`, allowing configurable control over which log item types are included in request and response logs. Also introduced the `DefaultLogItemType` enum for fine-grained log content control. [[1]](diffhunk://#diff-5d8a450345619b3c1b55599b67435798bf3129eacf25583089849e74bc6cb7d0R163-R194) [[2]](diffhunk://#diff-5d8a450345619b3c1b55599b67435798bf3129eacf25583089849e74bc6cb7d0R246-R249)
* Extended the logging system to support logging of extra contextual information via the `EXTRA_INFO` log item type and corresponding logic in log assembly. [[1]](diffhunk://#diff-6d68e1741faa4269d3c94cd2c131a1d566c0b3d0e06eddc9800a9a81cc8d98a9L32-R80) [[2]](diffhunk://#diff-5d8a450345619b3c1b55599b67435798bf3129eacf25583089849e74bc6cb7d0R163-R194) [[3]](diffhunk://#diff-5d8a450345619b3c1b55599b67435798bf3129eacf25583089849e74bc6cb7d0R246-R249)

### Reactive Logging Improvements

* Enhanced error handling in the reactive stack: if an error occurs during filter processing, the response log is still generated with the correct status code derived from the exception, ensuring complete logging even on failures. [[1]](diffhunk://#diff-7eb681ab095ae6f31e611223254c9c6d7e49f92aba4c503847b8b558242e57d9L31-R34) [[2]](diffhunk://#diff-8ff96a22fe108e48512dfda4a10bd69272ae8ed63269ca30186ba4dc7ef9da93R47-R58)
* Refactored the construction and propagation of logging decorators in the reactive stack to support the new `LogItem`-based API and extra info propagation. [[1]](diffhunk://#diff-b5bae5dddc0656d0928fff3acf2ea4caf023d4ec3f81d8936691535bdfc4581aR3-R19) [[2]](diffhunk://#diff-592c8cf980a74997bf3255218680383c77eca2a35d67453821b7cdead500a0d4R19-R28) [[3]](diffhunk://#diff-8ff96a22fe108e48512dfda4a10bd69272ae8ed63269ca30186ba4dc7ef9da93L28-R29)

### Dependency Update

* Bumped the library version in the documentation from `2.0.5` to `2.1.0` to reflect these breaking and feature changes.