### PR TITLE
ServletException에 대한 응답코드 처리

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add the dependency to your `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("com.github.codexwr:spring-boot-request-logging:2.1.1")
+    implementation("com.github.codexwr:spring-boot-request-logging:2.1.2")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "com.github.codexwr"
-version = "2.1.1"
+version = "2.1.2"
 
 java {
     toolchain {

--- a/src/main/java/com/github/codexwr/springbootrequestlogging/servlet/LoggingResponseWrapper.java
+++ b/src/main/java/com/github/codexwr/springbootrequestlogging/servlet/LoggingResponseWrapper.java
@@ -18,10 +18,10 @@ class LoggingResponseWrapper extends HttpServletResponseWrapper implements Loggi
         this.logPrinter = logPrinter;
     }
 
-    public void logPrint() {
+    public void logPrint(HttpStatusCode errorCode) {
         logPrinter.response(
                 executionTime(),
-                HttpStatusCode.valueOf(getStatus()),
+                errorCode != null ? errorCode : HttpStatusCode.valueOf(getStatus()),
                 getLogItem(loggingRequestWrapper, this, null)
         );
     }

--- a/src/test/java/com/github/codexwr/springbootrequestlogging/web/ReactiveLoggingTest.java
+++ b/src/test/java/com/github/codexwr/springbootrequestlogging/web/ReactiveLoggingTest.java
@@ -138,4 +138,26 @@ public class ReactiveLoggingTest {
                 .exchange()
                 .expectStatus().is4xxClientError();
     }
+
+    @Test
+    @DisplayName("Server RuntimeError")
+    public void runtimeError() {
+        // when
+        webClient.get()
+                .uri("/test/error")
+                .headers(it -> it.addAll(headers))
+                .exchange()
+                .expectStatus().is5xxServerError();
+    }
+
+    @Test
+    @DisplayName("Server RuntimeError(Async)")
+    public void runtimeErrorAsync() {
+        // when
+        webClient.get()
+                .uri("/test/error/async")
+                .headers(it -> it.addAll(headers))
+                .exchange()
+                .expectStatus().is5xxServerError();
+    }
 }

--- a/src/test/java/com/github/codexwr/springbootrequestlogging/web/ServletLoggingTest.java
+++ b/src/test/java/com/github/codexwr/springbootrequestlogging/web/ServletLoggingTest.java
@@ -1,6 +1,7 @@
 package com.github.codexwr.springbootrequestlogging.web;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +18,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -119,5 +121,17 @@ public class ServletLoggingTest {
         mvc.perform(req)
                 .andExpect(status().is4xxClientError())
                 .andDo(MockMvcResultHandlers.print());
+    }
+
+    @Test
+    @DisplayName("Server RuntimeError")
+    public void runtimeError() {
+        // when
+        var req = get("/test/error")
+                .queryParam("email", "test@example.org")
+                .headers(headers);
+
+        var exception = assertThrows(ServletException.class, () -> mvc.perform(req));
+        System.out.println(exception.getMessage());
     }
 }

--- a/src/test/java/com/github/codexwr/springbootrequestlogging/web/WebTestApplication.java
+++ b/src/test/java/com/github/codexwr/springbootrequestlogging/web/WebTestApplication.java
@@ -60,4 +60,15 @@ public class WebTestApplication {
 
         return Mono.just(ResponseEntity.ok(new ResponseDto(200, "OK")));
     }
+
+    @GetMapping("/error")
+    public ResponseEntity<ResponseDto> error() {
+        throw new RuntimeException("error");
+    }
+
+    @GetMapping("/error/async")
+    public Mono<ResponseEntity<ResponseDto>> errorAsync() {
+        return Mono.error(new RuntimeException("error async"));
+    }
+
 }


### PR DESCRIPTION
This pull request introduces improved error handling and logging for both servlet and reactive web environments, ensuring that the correct HTTP status codes are logged when exceptions occur. It also adds comprehensive tests to verify logging behavior during server errors. The most important changes are grouped below:

**Error Handling and Logging Improvements:**

* Refactored error handling in `LoggingWebExchange` (reactive) to determine and log the correct HTTP status code for exceptions, including those annotated with `@ResponseStatus`. Introduced the `determineStatusCode` helper method.
* Updated `DefaultServletLoggingFilter` and `LoggingResponseWrapper` (servlet) to pass and log the correct error status code when exceptions are thrown during request processing. [[1]](diffhunk://#diff-15958f754d5e2b6f8a6818f28a7d661c3f11e78682712e0899574bcda51a8c95R49-R66) [[2]](diffhunk://#diff-010b1a629855df31ad3d49a7bc528a9594ee64afbb428acbf4578935fbd173bfL21-R24)

**Dependency Update:**

* Updated the dependency version in the `README.md` example to `2.1.2`.

**Testing Enhancements:**

* Added new endpoints in `WebTestApplication` to simulate synchronous and asynchronous server errors for testing.
* Added tests in both `ReactiveLoggingTest` and `ServletLoggingTest` to verify correct logging and status codes for server-side errors, including async errors. [[1]](diffhunk://#diff-cf6867c6d17448c0211d77ec1bcf8525780df0ef12865bad2444d37790ec4577R141-R162) [[2]](diffhunk://#diff-1625b4c55a512dba08ab8b429b9b62e1097dea96b6fa8b41426881bcf85e3c6aR125-R136)

**Imports and Code Organization:**

* Added necessary imports for error handling and HTTP status codes in both servlet and reactive logging classes. [[1]](diffhunk://#diff-8ff96a22fe108e48512dfda4a10bd69272ae8ed63269ca30186ba4dc7ef9da93R5-R11) [[2]](diffhunk://#diff-15958f754d5e2b6f8a6818f28a7d661c3f11e78682712e0899574bcda51a8c95R12-R13) [[3]](diffhunk://#diff-1625b4c55a512dba08ab8b429b9b62e1097dea96b6fa8b41426881bcf85e3c6aR4) [[4]](diffhunk://#diff-1625b4c55a512dba08ab8b429b9b62e1097dea96b6fa8b41426881bcf85e3c6aR21)